### PR TITLE
Store generated executables

### DIFF
--- a/.github/workflows/elf64.yml
+++ b/.github/workflows/elf64.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: assemble-executable
-      run: nasm -felf64 elf64.asm && ld elf64.o
+      run: nasm -felf64 elf64.asm && ld elf64.o -o elf64
 
     - name: test-prints-helloworld
-      run: if [[ "$(./a.out)" != "Hello, World" ]]; then exit 1; fi
+      run: if [[ "$(./elf64)" != "Hello, World" ]]; then exit 1; fi

--- a/.github/workflows/macho64.yml
+++ b/.github/workflows/macho64.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: assemble-executable
-      run: nasm -fmacho64 macho64.asm && ld -e start -static macho64.o
+      run: nasm -fmacho64 macho64.asm && ld -e start -static macho64.o -o macho64
 
     - name: test-prints-helloworld
-      run: if [[ "$(./a.out)" != "Hello, World" ]]; then exit 1; fi
+      run: if [[ "$(./macho64)" != "Hello, World" ]]; then exit 1; fi

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -21,11 +21,11 @@ jobs:
       uses: actions/checkout@v2
 
     - name: assemble-executable
-      run: nasm -fwin64 win64.asm && gcc win64.obj
+      run: nasm -fwin64 win64.asm && gcc win64.obj -o win64.exe
 
     - name: test-prints-helloworld
       run: |-
-        $msg = &".\a.exe"
+        $msg = &".\win64.exe"
         If ($msg -ne "Hello") {
           exit 1
         }


### PR DESCRIPTION
The goal is to harness Github hosted-runners to build platform specific executables.
Usually, this kind of executables would be published as releases, but for this project
I believe it would be more useful to store them somewhere in the repo itself since we
want to creating some tooling around those binary files:
- parsing
- generating
- modifying
- ...